### PR TITLE
Add levelsanity_range to slot data & send bounce packet on map change

### DIFF
--- a/worlds/dragon_warrior/__init__.py
+++ b/worlds/dragon_warrior/__init__.py
@@ -189,6 +189,7 @@ class DragonWarriorWorld(World):
         return {
             "searchsanity": self.options.searchsanity.value,
             "levelsanity": self.options.levelsanity.value,
+            "levelsanity_range": self.options.levelsanity_range.value,
             "shopsanity": self.options.shopsanity.value,
             "monstersanity": self.options.monstersanity.value,
             "death_link": self.options.death_link.value

--- a/worlds/dragon_warrior/client.py
+++ b/worlds/dragon_warrior/client.py
@@ -28,6 +28,7 @@ class DragonWarriorClient(BizHawkClient):
     pending_deathlink = False
     own_deathlink = False
     item_queue: List[NetworkItem] = []
+    tracker_map: int = 0
 
     async def validate_rom(self, ctx: "BizHawkClientContext") -> bool:
         from worlds._bizhawk import RequestFailedError, read
@@ -91,6 +92,17 @@ class DragonWarriorClient(BizHawkClient):
         death_message += ENEMY_NAMES[enemy_id] + '.'
         ctx.last_death_link = time.time()
         await ctx.send_death(death_message)
+        
+    async def update_map(self, ctx: "BizHawkClientContext", current_map: int):
+        if self.tracker_map != current_map:
+            self.tracker_map = current_map
+            await ctx.send_msgs([{
+                "cmd": "Bounce",
+                "slots": [ctx.slot],
+                "data": {
+                    "current_map": self.tracker_map
+                }
+            }])
     
     async def game_watcher(self, ctx: "BizHawkClientContext"):
         from worlds._bizhawk import read, write
@@ -242,6 +254,9 @@ class DragonWarriorClient(BizHawkClient):
                 f'New Check: {location} ({len(ctx.locations_checked)}/'
                 f'{len(ctx.missing_locations) + len(ctx.checked_locations)})')
             await ctx.send_msgs([{"cmd": 'LocationChecks', "locations": [new_check_id]}])
+            
+        # Update map for Poptracker
+        await self.update_map(ctx, current_map[0])
 
         # Receive Items
         # Compare items_received index in the RAM at 0x0E to len(ctx.items_received)


### PR DESCRIPTION
## What is this fixing or adding?
Adds levelsanity_range to the slotdata, and sends a bounce packet whenever the game changes maps. These are both for external tracker purposes.

## How was this tested?
I did a test run, confirming that the levelsanity_range was present, and that all the bounce packets were sent out at the appropriate times.

## If this makes graphical changes, please attach screenshots.
N/A